### PR TITLE
masked password

### DIFF
--- a/lib/are_you_sure/form_builders/confirm_form_builder.rb
+++ b/lib/are_you_sure/form_builders/confirm_form_builder.rb
@@ -47,7 +47,7 @@ module AreYouSure
       when /text_area/
         text_area_field_value(field_value, *options)
       when /password/
-        '********'
+        password_field_value(field_value, *options)
       else
         field_value
       end
@@ -73,6 +73,10 @@ module AreYouSure
 
     def text_area_field_value(text, *options)
       text.gsub(/\r\n|\n|\r/, '<br />').html_safe
+    end
+
+    def password_field_value(password, *options)
+      '********'
     end
   end
 end


### PR DESCRIPTION
確認画面時にパスワードそのままではなく、決め打ちですが`********`と表示するようにしました。
