### PR TITLE
selected is false or nil?

### DIFF
--- a/lib/are_you_sure/form_builders/confirm_form_builder.rb
+++ b/lib/are_you_sure/form_builders/confirm_form_builder.rb
@@ -63,7 +63,7 @@ module AreYouSure
     end
 
     def select_field_value(selected, *options)
-      return '' unless selected
+      return '' if selected.nil?
       options.flatten.each_slice(2).to_a.detect {|i| i[1] == selected }[0]
     end
 


### PR DESCRIPTION
activerecordでbooleanの値はtrue/falseとして扱われますが、select_fieldでfalseを選択した場合に確認画面で空文字が表示される現象がありました。該当箇所の意図として`selected`は`true or false`ではなく、`nil or not nil`で問題ないと判断したためdiffのように修正しました。

また

``` ruby
    def collection_field_value(selected, choices, value_method, text_method, *options)
      return '' unless selected
      choices.detect {|c| c.send(value_method) == selected }.send(text_method)
    end
```

に関しても同様の意図であれば修正する必要があるかもしれません。
