### PR TITLE
enable link_to option

### DIFF
--- a/lib/are_you_sure/form_builders/confirm_form_builder.rb
+++ b/lib/are_you_sure/form_builders/confirm_form_builder.rb
@@ -21,7 +21,8 @@ module AreYouSure
       cancel_path = options.delete(:to) || @template.polymorphic_path(@object, action: @object.persisted? ? :edit : :new)
       @template.link_to(
         value || I18n.t('are_you_sure.helpers.cancel', default: 'Cancel'),
-        cancel_path
+        cancel_path,
+        options
       )
     end
 


### PR DESCRIPTION
確認画面のキャンセルボタンを生成している部分のlink_toにoptionsを渡せるようにしました。
