### PR TITLE
update時は不要

### DIFF
--- a/lib/are_you_sure/confirmable.rb
+++ b/lib/are_you_sure/confirmable.rb
@@ -16,7 +16,7 @@ module AreYouSure
     end
 
     def update_if_confirmed(attributes)
-      self.attributes = attributes
+      self.attributes = attributes unless confirmed?
       confirm_with_persist { self.update(attributes) }
     end
 


### PR DESCRIPTION
確認画面ではparamsの値をselfに入れる必要があるため

```
self.attributes = attributes
```

が必要ですが、update時は不要であるため代入しないようにしました。

具体的な問題としては、nestedなobjectがある場合に複数個追加されてしまう等のバグが発生していました（おそらくid不一致のため）。
